### PR TITLE
Store index.html as a file

### DIFF
--- a/src/index.html.tmpl
+++ b/src/index.html.tmpl
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+<html>
+	<head>
+		<!--
+This program is free software: you can redistribute it and/or  modify
+it under the terms of the GNU Affero General Public License, version 3,
+as published by the Free Software Foundation.
+The source code, along with the full license text, is available here:
+https://github.com/euank/rms.sexy
+
+It is also available at "/code.tar.gz" on this server.
+		-->
+		<meta charset="utf-8">
+		<title>${title}</title>
+		${extra_meta}
+		<link rel="stylesheet" href="/style.css">
+		<link rel="license" href="/license.txt">
+		<script async src="/script.js"></script>
+	</head>
+	<body>
+		<a href="https://donate.fsf.org/"><img class="donate" src="/donate.png" alt="Donate!" title="Donate to the FSF!"></a>
+		<a href="/"><img alt="RMS Matthew Stallman" class="stallman" src="${img}" height="100%"></a>
+	</body>
+</html>


### PR DESCRIPTION
This moves it from being inline in the rust code to being a templated
file.

Minimal templating is done by search/replace of values in rust.

This is to make it easier for someone else to read or edit the html.

cc @Mechazawa since this is per your suggestion.